### PR TITLE
Add spacing after class-level Javadoc comments

### DIFF
--- a/Juego_por_turnos/src/entidades/Arma.java
+++ b/Juego_por_turnos/src/entidades/Arma.java
@@ -8,6 +8,7 @@ package entidades;
  *
  * @author Jairo Herrera Romero
  */
+
 // entidades/Arma.java
 public class Arma {
     private int id;

--- a/Juego_por_turnos/src/modelos/Humano.java
+++ b/Juego_por_turnos/src/modelos/Humano.java
@@ -8,6 +8,7 @@ package modelos;
  *
  * @author Jairo Herrera Romero
  */
+
 // modelos/Humano.java
 import entidades.Arma;
 import entidades.Raza;


### PR DESCRIPTION
Inserted a blank line between class-level Javadoc comments and class declarations in Arma and Humano for improved readability.